### PR TITLE
[Improvement] Поддержка локализации

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,13 @@ check:
 	# max length is based on Black defaults
 	poetry run black --check src
 	poetry run isort --line-length 88 --check-only src
-	poetry run flake8 --max-line-length 88 src
+	poetry run flake8 --builtins='_' --max-line-length 88 src
 	poetry run pydocstyle src
+
+l10n-update:
+	poetry run pybabel extract src -o src/locale/base.pot
+	poetry run pybabel update -i src/locale/base.pot -d src/locale
+
+l10n-compile:
+	poetry run pybabel compile -d src/locale
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "babel"
+version = "2.9.1"
+description = "Internationalization utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pytz = ">=2015.7"
+
+[[package]]
 name = "black"
 version = "20.8b1"
 description = "The uncompromising code formatter."
@@ -155,6 +166,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pytz"
+version = "2021.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "regex"
 version = "2021.3.17"
 description = "Alternative regular expression module, to replace re."
@@ -240,12 +259,16 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a7e6222e09b44fd1f7712292a7d32fd470326ed1ec2325e7887b7e652a92b3aa"
+content-hash = "8eb96d8304ddfa29aed854d90f516b1345d065cfcf9771896cc90cd4c12e6ba0"
 
 [metadata.files]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+babel = [
+    {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
+    {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -301,6 +324,10 @@ pydocstyle = [
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+pytz = [
+    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
+    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 regex = [
     {file = "regex-2021.3.17-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0"
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = "^2.25.1"
+Babel = "^2.9.1"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Main module of application."""
-
+import gettext
 import tkinter as tk
 
 from controllers.app import AppController
@@ -9,6 +9,7 @@ from controllers.app import AppController
 
 def main():
     """Application entry point."""
+    gettext.install("messages", localedir="locale")
     root = tk.Tk()
     root.columnconfigure(0, weight=1)
     root.rowconfigure(0, weight=1)

--- a/src/controllers/app.py
+++ b/src/controllers/app.py
@@ -11,7 +11,7 @@ from views.notes.notes import NotesView
 class AppController:
     """Application controller (root controller)."""
 
-    _title = "Overview"  # TODO: интернационализация
+    _title = "Overview"
 
     def __init__(self, root):
         """Construct controller."""

--- a/src/locale/en_US/LC_MESSAGES/messages.po
+++ b/src/locale/en_US/LC_MESSAGES/messages.po
@@ -1,0 +1,108 @@
+# English (United States) translations for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: paperlark@yandex.com\n"
+"POT-Creation-Date: 2021-05-05 21:37+0300\n"
+"PO-Revision-Date: 2021-05-05 20:02+0300\n"
+"Last-Translator: Max Zhuravsky <paperlark@yandex.com>\n"
+"Language: en_US\n"
+"Language-Team: en_US <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: src/utils/formatters.py:21
+msgid "Sunny"
+msgstr "Sunny"
+
+#: src/utils/formatters.py:22
+msgid "Rainy"
+msgstr "Rainy"
+
+#: src/utils/formatters.py:23
+msgid "Cloudy"
+msgstr "Cloudy"
+
+#: src/utils/formatters.py:24
+msgid "Storm"
+msgstr "Storm"
+
+#: src/utils/formatters.py:25
+msgid "Drizzle"
+msgstr "Drizzle"
+
+#: src/utils/formatters.py:26
+msgid "Snow"
+msgstr "Snow"
+
+#: src/utils/formatters.py:57
+msgid "mmHg"
+msgstr "mmHg"
+
+#: src/utils/formatters.py:63
+msgid "N"
+msgstr "N"
+
+#: src/utils/formatters.py:65
+msgid "NE"
+msgstr "NE"
+
+#: src/utils/formatters.py:67
+msgid "E"
+msgstr "E"
+
+#: src/utils/formatters.py:69
+msgid "SE"
+msgstr "SE"
+
+#: src/utils/formatters.py:71
+msgid "S"
+msgstr "S"
+
+#: src/utils/formatters.py:73
+msgid "SW"
+msgstr "SW"
+
+#: src/utils/formatters.py:75
+msgid "W"
+msgstr "W"
+
+#: src/utils/formatters.py:77
+msgid "NW"
+msgstr "NW"
+
+#: src/views/app/app_bar.py:52
+msgid "Notes"
+msgstr "Notes"
+
+#: src/views/app/app_bar.py:53
+msgid "Weather"
+msgstr "Weather"
+
+#: src/views/app/app_bar.py:54
+msgid "Calendar"
+msgstr "Calendar"
+
+#: src/views/shared/loading.py:27
+msgid "Loading…"
+msgstr "Loading…"
+
+#: src/views/weather/current_weather.py:42
+msgid "Humidity"
+msgstr "Humidity"
+
+#: src/views/weather/current_weather.py:45
+msgid "Pressure"
+msgstr "Pressure"
+
+#: src/views/weather/current_weather.py:67
+msgid "Refresh"
+msgstr "Refresh"
+

--- a/src/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/src/locale/ru_RU/LC_MESSAGES/messages.po
@@ -1,0 +1,109 @@
+# Russian (Russia) translations for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: paperlark@yandex.com\n"
+"POT-Creation-Date: 2021-05-05 21:37+0300\n"
+"PO-Revision-Date: 2021-05-05 20:04+0300\n"
+"Last-Translator: Max Zhuravsky <paperlark@yandex.com>\n"
+"Language: ru_RU\n"
+"Language-Team: ru_RU <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: src/utils/formatters.py:21
+msgid "Sunny"
+msgstr "Солнечно"
+
+#: src/utils/formatters.py:22
+msgid "Rainy"
+msgstr "Дождь"
+
+#: src/utils/formatters.py:23
+msgid "Cloudy"
+msgstr "Облачно"
+
+#: src/utils/formatters.py:24
+msgid "Storm"
+msgstr "Гроза"
+
+#: src/utils/formatters.py:25
+msgid "Drizzle"
+msgstr "Туман"
+
+#: src/utils/formatters.py:26
+msgid "Snow"
+msgstr "Снег"
+
+#: src/utils/formatters.py:57
+msgid "mmHg"
+msgstr "мм"
+
+#: src/utils/formatters.py:63
+msgid "N"
+msgstr "С"
+
+#: src/utils/formatters.py:65
+msgid "NE"
+msgstr "СВ"
+
+#: src/utils/formatters.py:67
+msgid "E"
+msgstr "В"
+
+#: src/utils/formatters.py:69
+msgid "SE"
+msgstr "ЮВ"
+
+#: src/utils/formatters.py:71
+msgid "S"
+msgstr "Ю"
+
+#: src/utils/formatters.py:73
+msgid "SW"
+msgstr "ЮЗ"
+
+#: src/utils/formatters.py:75
+msgid "W"
+msgstr "З"
+
+#: src/utils/formatters.py:77
+msgid "NW"
+msgstr "СЗ"
+
+#: src/views/app/app_bar.py:52
+msgid "Notes"
+msgstr "Заметки"
+
+#: src/views/app/app_bar.py:53
+msgid "Weather"
+msgstr "Погода"
+
+#: src/views/app/app_bar.py:54
+msgid "Calendar"
+msgstr "Календарь"
+
+#: src/views/shared/loading.py:27
+msgid "Loading…"
+msgstr "Загружаем данные…"
+
+#: src/views/weather/current_weather.py:42
+msgid "Humidity"
+msgstr "Влажность"
+
+#: src/views/weather/current_weather.py:45
+msgid "Pressure"
+msgstr "Давление"
+
+#: src/views/weather/current_weather.py:67
+msgid "Refresh"
+msgstr "Обновить"
+

--- a/src/utils/formatters.py
+++ b/src/utils/formatters.py
@@ -2,26 +2,28 @@
 """Utils for text formatting."""
 import datetime
 
-from models.weather import WeatherKind
+import babel.dates as dates
+import babel.units as units
 
-# TODO: интернациоанлизация
+from models.weather import WeatherKind
 
 
 def format_temperature(temp: float) -> str:
-    """Format temperature in Celcius."""
-    return f"{int(temp)}℃"
+    """Format temperature in Celsius."""
+    return units.format_unit(int(temp), "temperature-celsius", "short")
 
 
 def format_weather_kind(kind: WeatherKind, with_desc: bool = False) -> str:
     """Format weather kind."""
     if with_desc:
+        icon = format_weather_kind(kind)
         return {
-            WeatherKind.SUNNY: "Sunny ☀️",
-            WeatherKind.RAIN: "Rainy ☔️",
-            WeatherKind.CLOUDY: "Cloudy ☁️",
-            WeatherKind.STORM: "Storm ⚡️",
-            WeatherKind.DRIZZLE: "Drizzle ☔️",
-            WeatherKind.SNOW: "Snow ❄️",
+            WeatherKind.SUNNY: _("Sunny") + " " + icon,
+            WeatherKind.RAIN: _("Rainy") + " " + icon,
+            WeatherKind.CLOUDY: _("Cloudy") + " " + icon,
+            WeatherKind.STORM: _("Storm") + " " + icon,
+            WeatherKind.DRIZZLE: _("Drizzle") + " " + icon,
+            WeatherKind.SNOW: _("Snow") + " " + icon,
         }[kind]
     else:
         return {
@@ -36,29 +38,42 @@ def format_weather_kind(kind: WeatherKind, with_desc: bool = False) -> str:
 
 def format_time(t: datetime.time) -> str:
     """Format time."""
-    return t.strftime("%H:%M")
+    return dates.format_time(t, format="short")
 
 
 def format_wind(speed: float, direction: float) -> str:
     """Format wind parameters."""
-    return f"💨 {speed} m/s, {format_direction(direction)}"
+    formatted_speed = units.format_unit(speed, "speed-meter-per-second", "short")
+    return f"💨 {formatted_speed}, {format_direction(direction)}"
+
+
+def format_pressure(pressure_in_pa: float) -> str:
+    """Format pressure."""
+    pressure_in_mm_hg = int(pressure_in_pa * 0.00750062)
+    try:
+        return units.format_unit(
+            pressure_in_mm_hg, "pressure-millimeter-of-mercury", "short"
+        )
+    except units.UnknownUnitError:
+        # NOTE: для русского языка нет перевода
+        return str(pressure_in_mm_hg) + " " + _("mmHg")
 
 
 def format_direction(direction_in_degrees: float) -> str:
     """Format direction given in degrees."""
     if direction_in_degrees <= 22.5 or direction_in_degrees > 337.5:
-        return "N"
+        return _("N")
     elif direction_in_degrees <= 67.5:
-        return "NE"
+        return _("NE")
     elif direction_in_degrees <= 112.5:
-        return "E"
+        return _("E")
     elif direction_in_degrees <= 157.5:
-        return "SE"
+        return _("SE")
     elif direction_in_degrees <= 202.5:
-        return "S"
+        return _("S")
     elif direction_in_degrees <= 247.5:
-        return "SW"
+        return _("SW")
     elif direction_in_degrees <= 292.5:
-        return "W"
+        return _("W")
     else:
-        return "NW"
+        return _("NW")

--- a/src/views/app/app_bar.py
+++ b/src/views/app/app_bar.py
@@ -21,15 +21,9 @@ class AppBarViewProps:
 class AppBarView(View[AppBarViewProps]):
     """View for application bar."""
 
-    __tab_names = {
-        WidgetKind.NOTES: "Notes",
-        WidgetKind.WEATHER: "Weather",
-        WidgetKind.CALENDAR: "Calendar",
-    }  # TODO: интернационализация
-
     def _update(self):
         for btn in self.__buttons:
-            btn.destroy()  # TODO: add convenience method for removing children
+            btn.destroy()
 
         self.__buttons = [
             self.__render_button(i, t) for i, t in enumerate(self.props.tabs)
@@ -54,6 +48,11 @@ class AppBarView(View[AppBarViewProps]):
 
     @classmethod
     def __get_tab_name(cls, tab_kind):
-        if tab_kind not in cls.__tab_names:
+        tab_names = {
+            WidgetKind.NOTES: _("Notes"),
+            WidgetKind.WEATHER: _("Weather"),
+            WidgetKind.CALENDAR: _("Calendar"),
+        }
+        if tab_kind not in tab_names:
             raise Exception(f"unsupported tab kind={tab_kind}")
-        return cls.__tab_names[tab_kind]
+        return tab_names[tab_kind]

--- a/src/views/shared/loading.py
+++ b/src/views/shared/loading.py
@@ -9,8 +9,6 @@ from views.shared.flexible import Flexible
 class LoadingScreen(Flexible(tk.Frame)):
     """Loading screen widget."""
 
-    _loading_text = "Loading…"  # TODO: internationalize
-
     def __init__(self, *args, **kwargs):
         """Construct widget."""
         super().__init__(*args, **kwargs)
@@ -26,7 +24,7 @@ class LoadingScreen(Flexible(tk.Frame)):
 
     def _render(self):
         self.rowconfigure(1, weight=1)
-        self.__text = tk.Label(self, text=self._loading_text)
+        self.__text = tk.Label(self, text=_("Loading…"))
         self.__text.grid(row=0, column=0, pady=16, sticky="S")
         self.__loading = ttk.Progressbar(self, mode="indeterminate")
         self.__loading.grid(row=1, column=0, padx=64, pady=16, sticky="NEW")

--- a/src/views/weather/current_weather.py
+++ b/src/views/weather/current_weather.py
@@ -5,8 +5,8 @@ import tkinter as tk
 from dataclasses import dataclass
 from typing import Callable
 
+import utils.formatters as fmt
 from models.weather import InstantForecast
-from utils.formatters import format_temperature, format_weather_kind, format_wind
 from views.shared.flexible import Flexible
 from views.shared.view import View
 
@@ -24,23 +24,27 @@ class CurrentWeatherView(View[CurrentWeatherViewProps]):
 
     def _update(self):
         self.__real_temp.configure(
-            text=format_temperature(self.props.forecast.real_temp)
+            text=fmt.format_temperature(self.props.forecast.real_temp)
         )
         self.__feels_like.configure(
-            text="(" + format_temperature(self.props.forecast.feels_like_temp) + ")"
+            text="(" + fmt.format_temperature(self.props.forecast.feels_like_temp) + ")"
         )
         self.__weather_kind.configure(
-            text=format_weather_kind(self.props.forecast.kind, with_desc=True)
+            text=fmt.format_weather_kind(self.props.forecast.kind, with_desc=True)
         )
         self.__wind.configure(
-            text=format_wind(
+            text=fmt.format_wind(
                 self.props.forecast.wind_speed, self.props.forecast.wind_direction
             )
         )
         self.__refresh.configure(command=self.props.on_refresh)
-        self.__humidity.configure(text=f"Humidity: {self.props.forecast.humidity}%")
+        self.__humidity.configure(
+            text=_("Humidity") + f": {self.props.forecast.humidity}%"
+        )
         self.__pressure.configure(
-            text=f"Pressure: {int(self.props.forecast.pressure * 0.00750062)} mmHg"
+            text=_("Pressure")
+            + ": "
+            + fmt.format_pressure(self.props.forecast.pressure)
         )
 
     def _render_widgets(self):
@@ -63,7 +67,7 @@ class CurrentWeatherView(View[CurrentWeatherViewProps]):
             fg="#777777",
         )
         self.__feels_like.grid(row=0, column=0, sticky="NEWS")
-        self.__refresh = tk.Button(container, text="↺")
+        self.__refresh = tk.Button(container, text=_("Refresh"))
         self.__refresh.grid(row=0, column=1, sticky="SE")
 
         self.__weather_kind = Flexible(tk.Label)(

--- a/src/views/weather/weather.py
+++ b/src/views/weather/weather.py
@@ -30,8 +30,6 @@ class WeatherView(View[WeatherViewProps]):
             self.__loading.lift()
             return
 
-        self.__loading.stop()
-        self.__loading.lower()
         self.__current.update_props(
             CurrentWeatherViewProps(
                 forecast=self.props.forecast.current,
@@ -41,6 +39,8 @@ class WeatherView(View[WeatherViewProps]):
         self.__today.update_props(
             TodayWeatherViewProps(forecasts=self.props.forecast.hourly)
         )
+        self.__loading.stop()
+        self.__loading.lower()
 
     def _render_widgets(self):
         self.__container = Flexible(ttk.Frame)(self)


### PR DESCRIPTION
**Как это работает:**
- для локализации единиц измерения и числовых значений в библиотеке babel есть стандартные функции форматирования
- все остальные лэйблы надо оборачивать в вызовы функции `_()`; она появляется в глобальном скоупе после  инициализации переводчика вызовом функции `gettext.install()` и служит для получения перевода определенного лэйбла
- перевод осуществляется за счет поиска лэйбла в словаре переводов для всех лэйблов, созданном заранее и переданном в `gettext.install()`:
  - базовый словарь находится в `src/locale/base.pot`;
  - на его основе можно создавать словари с переводами для определенных локалей;
  - это словари компилируются в `*.mo` файлы, которые используется при поиске перевода.

**Изменения:**
- добавил локализацию текстов с помощью babel
- для обновления словарей добавил команду `make l10n-update`
- для компиляции словарей в `*.mo` файлы добавил команду `make l10n-compile`

**Как попробовать:**
- скомпилировать словари: `make l10n-compile`
- запустить приложение из папки `src` с указанием локали: `env LC_ALL=ru_RU poetry run python .`

Closes #13